### PR TITLE
Feature/s3 conditional put

### DIFF
--- a/crates/s3/Cargo.lock
+++ b/crates/s3/Cargo.lock
@@ -488,6 +488,7 @@ name = "aws_utils_s3"
 version = "0.2.0"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "aws-smithy-types-convert",
  "futures-util",

--- a/crates/s3/Cargo.lock
+++ b/crates/s3/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "aws_utils_s3"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "asynchronous", "web-programming"]
 
 [dependencies]
 aws-config = { version = "1.8", features = ["behavior-version-latest"] }
+aws-credential-types = "1"
 aws-sdk-s3 = "1"
 aws-smithy-types-convert = { version = "0.60.9", features = ["convert-streams"] }
 futures-util = "0.3.31"

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_s3"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS S3 utilities for common operations like listing, uploading, downloading, and deleting objects"
 repository = "https://github.com/UniqueVision/utilities.aws-utils"

--- a/crates/s3/src/object.rs
+++ b/crates/s3/src/object.rs
@@ -110,6 +110,28 @@ pub async fn put_object(
         .map_err(from_aws_sdk_error)
 }
 
+pub async fn put_object_conditional(
+    client: &Client,
+    bucket_name: impl Into<String>,
+    key: impl Into<String>,
+    body: impl Into<ByteStream>,
+    if_match: impl Into<String>,
+    content_type: Option<impl Into<String>>,
+    content_disposition: Option<impl Into<String>>,
+) -> Result<PutObjectOutput, Error> {
+    client
+        .put_object()
+        .set_bucket(Some(bucket_name.into()))
+        .set_key(Some(key.into()))
+        .set_body(Some(body.into()))
+        .set_if_match(Some(if_match.into()))
+        .set_content_type(content_type.map(Into::into))
+        .set_content_disposition(content_disposition.map(Into::into))
+        .send()
+        .await
+        .map_err(from_aws_sdk_error)
+}
+
 pub async fn put_object_from_path(
     client: &Client,
     bucket_name: impl Into<String>,


### PR DESCRIPTION
 ## 概要
  S3クライアントに条件付き書き込み機能と手動認証情報設定機能を追加

  ## 変更内容

  ### ✨ 新機能

  #### 1. 条件付き書き込みメソッド `put_object_conditional`
  - `if_match` パラメータを使用してETagベースの条件付き書き込みを実現
  - 楽観的ロックの実装に使用可能
  - オブジェクトの現在のETagと指定されたETagが一致する場合のみ書き込みを実行

  #### 2. 手動認証情報設定機能 `make_client_with_credentials`
  - アクセスキーとシークレットキーを直接指定してクライアントを作成
  - カスタムエンドポイントURLのサポート（MinIOなどのS3互換サービス対応）
  - タイムアウト設定のオプショナルサポート

  ### 📦 依存関係
  - `aws-credential-types` クレートを追加（手動認証情報設定に必要）