### PR TITLE
Feature/remove dummy env

### DIFF
--- a/crates/athena/CHANGELOG.md
+++ b/crates/athena/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changes
 
+### v0.1.2 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.1.1 (2025/08/12)
 * modify timeout
 

--- a/crates/athena/Cargo.toml
+++ b/crates/athena/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_athena"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "AWS Athena client utilities for Rust with query execution, streaming results, and comprehensive error handling"
 readme = "README.md"

--- a/crates/athena/README.md
+++ b/crates/athena/README.md
@@ -139,12 +139,14 @@ match query::start_query_execution(&client, query_string, None, None, None, None
 }
 ```
 
-## Environment Variables
+## Authentication
 
-The client automatically sets default values for AWS credentials and region if not provided:
-- `AWS_ACCESS_KEY_ID`: Defaults to "dummy_access_key"
-- `AWS_SECRET_ACCESS_KEY`: Defaults to "dummy_secret_key"
-- `AWS_REGION`: Defaults to "us-west-2"
+The client uses the AWS SDK's default credential chain for authentication:
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ## License
 

--- a/crates/athena/src/lib.rs
+++ b/crates/athena/src/lib.rs
@@ -41,15 +41,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/dynamodb/CHANGELOG.md
+++ b/crates/dynamodb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ## v0.2.0 (2025/08/14)
 * add make_client with timeout
 

--- a/crates/dynamodb/Cargo.toml
+++ b/crates/dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_dynamodb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS DynamoDB utilities for Rust"
 repository = "https://github.com/UniqueVision/utilities.aws-utils"

--- a/crates/dynamodb/README.md
+++ b/crates/dynamodb/README.md
@@ -221,12 +221,12 @@ The crate provides a custom `Error` type that wraps AWS SDK errors and includes 
 
 ## Environment Variables
 
-The client creation automatically sets default values for AWS credentials if not present:
-- `AWS_ACCESS_KEY_ID` - Defaults to "dummy_access_key"
-- `AWS_SECRET_ACCESS_KEY` - Defaults to "dummy_secret_key"
-- `AWS_REGION` - Defaults to "us-west-2"
-
-These defaults are useful for local development with DynamoDB Local.
+The client uses the AWS SDK's default credential chain, which checks for credentials in the following order:
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ## License
 

--- a/crates/dynamodb/src/lib.rs
+++ b/crates/dynamodb/src/lib.rs
@@ -45,15 +45,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/firehose/CHANGELOG.md
+++ b/crates/firehose/CHANGELOG.md
@@ -1,13 +1,10 @@
-# Changes
+## Changes
 
-## v0.2.1 (2025/09/13)
+### v0.1.1 (2025/09/13)
 * **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
 * Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
 * Now properly uses AWS SDK's default credential chain
 * Updated README documentation to reflect new authentication behavior
 
-## v0.2.0 (2025/08/15)
-* add make_client with timeout
-
-## v0.1.0 (2025/07/24)
+### v0.1.0 (2025/07/17)
 * first release

--- a/crates/firehose/Cargo.toml
+++ b/crates/firehose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_firehose"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "AWS Kinesis Data Firehose utilities for Rust"
 documentation = "https://docs.rs/aws-firehose-utils"

--- a/crates/firehose/src/lib.rs
+++ b/crates/firehose/src/lib.rs
@@ -40,15 +40,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/kinesis_data_streams/CHANGELOG.md
+++ b/crates/kinesis_data_streams/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changes
 
+### v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.2.0 (2025/08/14)
 * add make_client with timeout
 

--- a/crates/kinesis_data_streams/Cargo.toml
+++ b/crates/kinesis_data_streams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_kinesis_data_streams"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS Kinesis Data Streams utilities for Rust"
 readme = "README.md"

--- a/crates/kinesis_data_streams/README.md
+++ b/crates/kinesis_data_streams/README.md
@@ -229,15 +229,15 @@ The library includes comprehensive unit tests with mocking capabilities using `m
 
 ## Configuration
 
-### Environment Variables
+### Authentication
 
-The library automatically sets dummy AWS credentials for testing if not provided:
+The client uses the AWS SDK's default credential chain for authentication:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `AWS_REGION`
-
-For production use, configure these through your preferred AWS credential provider.
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ## Dependencies
 

--- a/crates/kinesis_data_streams/src/lib.rs
+++ b/crates/kinesis_data_streams/src/lib.rs
@@ -43,15 +43,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/lambda/CHANGELOG.md
+++ b/crates/lambda/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changes
 
+### v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.2.0 (2025/08/14)
 * add make_client with timeout
 

--- a/crates/lambda/Cargo.toml
+++ b/crates/lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_lambda"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS Lambda utilities for Rust"
 readme = "README.md"

--- a/crates/lambda/README.md
+++ b/crates/lambda/README.md
@@ -35,10 +35,12 @@ async fn main() {
 }
 ```
 
-The client creation functions automatically handle AWS credentials:
-- Uses existing AWS environment variables if set
-- Sets dummy values for local development if not configured
-- Defaults to `us-west-2` region if `AWS_REGION` is not set
+The client uses the AWS SDK's default credential chain for authentication:
+- Environment variables if set
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ### Timeout Configuration
 

--- a/crates/lambda/src/lib.rs
+++ b/crates/lambda/src/lib.rs
@@ -41,15 +41,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/s3/CHANGELOG.md
+++ b/crates/s3/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## v0.2.2 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
+## v0.2.1 (2025/08/14)
+* Version number correction
+
 ## v0.2.0 (2025/08/14)
 * add make_client with timeout
 

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_s3"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "AWS S3 utilities for common operations like listing, uploading, downloading, and deleting objects"
 repository = "https://github.com/UniqueVision/utilities.aws-utils"

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -45,15 +45,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changes
 
+### v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.2.0 (2025/08/15)
 * add make_client with timeout
 

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_scheduler"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A Rust wrapper for AWS EventBridge Scheduler with type-safe builders for schedule expressions"
 documentation = "https://docs.rs/aws_utils_scheduler"

--- a/crates/scheduler/README.md
+++ b/crates/scheduler/README.md
@@ -331,10 +331,10 @@ match scheduler::create_schedule(
 
 ## Important Notes
 
-- All client creation functions (`make_client`, `make_client_with_timeout`, `make_client_with_timeout_default`) set dummy AWS credentials if they're not already present in the environment. This is useful for local development with tools like LocalStack.
 - The `make_client_with_timeout_default` function provides reasonable default timeout values (connect: 3100s, operation: 60s, operation attempt: 55s, read: 50s) suitable for most use cases.
 - All schedule names must be unique within a schedule group.
 - The IAM role must have the necessary permissions to invoke the target.
+- The client uses the AWS SDK's default credential chain, supporting IAM roles, environment variables, and other standard authentication methods.
 
 ## License
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -42,15 +42,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> aws_sdk_scheduler::Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/secretsmanager/Cargo.toml
+++ b/crates/secretsmanager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_secretsmanager"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS Secrets Manager utilities for retrieving secret values"
 license = "MIT"

--- a/crates/secretsmanager/README.md
+++ b/crates/secretsmanager/README.md
@@ -8,7 +8,7 @@ AWS Secrets Manager utilities for retrieving secret values from AWS Secrets Mana
 - Support for secret versioning with version ID and version stage
 - Custom error handling with detailed error types
 - Support for custom AWS endpoints (useful for testing with LocalStack)
-- Automatic fallback to dummy credentials for testing environments
+- Support for AWS SDK's default credential chain
 
 ## Installation
 
@@ -259,15 +259,15 @@ RUST_LOG=info cargo test -- --nocapture
 cargo test test_get_secret_value -- --nocapture
 ```
 
-## Environment Variables
+## Authentication
 
-The crate automatically sets dummy AWS credentials if they're not present:
+The client uses the AWS SDK's default credential chain for authentication:
 
-- `AWS_ACCESS_KEY_ID`: Set to "dummy_access_key" if not present
-- `AWS_SECRET_ACCESS_KEY`: Set to "dummy_secret_key" if not present  
-- `AWS_REGION`: Set to "us-west-2" if not present
-
-This makes it easy to use in testing environments without requiring real AWS credentials.
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ## Use Cases
 

--- a/crates/secretsmanager/src/lib.rs
+++ b/crates/secretsmanager/src/lib.rs
@@ -42,15 +42,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/sqs/CHANGELOG.md
+++ b/crates/sqs/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changes
 
+### v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.2.0 (2025/08/15)
 * add make_client with timeout
 

--- a/crates/sqs/Cargo.toml
+++ b/crates/sqs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_sqs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS SQS utilities for Rust"
 homepage = "https://github.com/UniqueVision/utilities.aws-utils"

--- a/crates/sqs/src/lib.rs
+++ b/crates/sqs/src/lib.rs
@@ -43,15 +43,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);

--- a/crates/ssm/CHANGELOG.md
+++ b/crates/ssm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+### v0.2.1 (2025/09/13)
+* **BREAKING CHANGE**: Removed automatic dummy credential injection from make_client functions
+* Fixed authentication issues in ECS/Fargate environments where IAM task roles should be used
+* Now properly uses AWS SDK's default credential chain
+* Updated README documentation to reflect new authentication behavior
+
 ### v0.2.0 (2025/08/15)
 * add make_client with timeout
 

--- a/crates/ssm/Cargo.toml
+++ b/crates/ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_ssm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "AWS SSM utilities for getting parameter values from AWS Systems Manager Parameter Store"
 license = "MIT"

--- a/crates/ssm/README.md
+++ b/crates/ssm/README.md
@@ -8,7 +8,7 @@ AWS SSM utilities for getting parameter values from AWS Systems Manager Paramete
 - Support for encrypted parameters with automatic decryption
 - Custom error handling with detailed error types
 - Support for custom AWS endpoints (useful for testing with LocalStack)
-- Automatic fallback to dummy credentials for testing environments
+- Support for AWS SDK's default credential chain
 
 ## Installation
 
@@ -219,15 +219,15 @@ RUST_LOG=info cargo test -- --nocapture
 cargo test test_get_parameter -- --nocapture
 ```
 
-## Environment Variables
+## Authentication
 
-The crate automatically sets dummy AWS credentials if they're not present:
+The client uses the AWS SDK's default credential chain for authentication:
 
-- `AWS_ACCESS_KEY_ID`: Set to "dummy_access_key" if not present
-- `AWS_SECRET_ACCESS_KEY`: Set to "dummy_secret_key" if not present  
-- `AWS_REGION`: Set to "us-west-2" if not present
-
-This makes it easy to use in testing environments without requiring real AWS credentials.
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- ECS task role (for Fargate/ECS)
+- EC2 instance profile
+- AWS credentials file
+- Other configured credential providers
 
 ## License
 

--- a/crates/ssm/src/lib.rs
+++ b/crates/ssm/src/lib.rs
@@ -42,15 +42,6 @@ pub async fn make_client(
     endpoint_url: Option<String>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Client {
-    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
-        unsafe { std::env::set_var("AWS_ACCESS_KEY_ID", "dummy_access_key") };
-    }
-    if std::env::var("AWS_SECRET_ACCESS_KEY").is_err() {
-        unsafe { std::env::set_var("AWS_SECRET_ACCESS_KEY", "dummy_secret_key") };
-    }
-    if std::env::var("AWS_REGION").is_err() {
-        unsafe { std::env::set_var("AWS_REGION", "us-west-2") };
-    }
     let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
     if let Some(timeout_config) = timeout_config {
         config_loader = config_loader.timeout_config(timeout_config);


### PR DESCRIPTION
ダミー環境変数による認証がECSタスクの実行ロールによる認証より優先順位が高いためECSの中で使えない問題がおこりました。

ダミー設定を削除することで対応しています。