### PR TITLE
Feature-query-with-limit

### DIFF
--- a/crates/dynamodb/CHANGELOG.md
+++ b/crates/dynamodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## v0.5.0 (2025/12/12)
+
+* Add `query` function for single query with limit (no pagination)
+
 ## v0.4.0 (2025/09/19)
 * **BREAKING CHANGE**: query and scan add consistent_read, expression_attribute_names, projection_expression, attributes_to_get
 

--- a/crates/dynamodb/Cargo.toml
+++ b/crates/dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_utils_dynamodb"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "AWS DynamoDB utilities for Rust"
 repository = "https://github.com/UniqueVision/utilities.aws-utils"

--- a/crates/dynamodb/README.md
+++ b/crates/dynamodb/README.md
@@ -55,7 +55,7 @@ let client = make_client(Some("http://localhost:8000".to_string()), None).await;
 ### Record Operations
 
 ```rust
-use aws_utils_dynamodb::record::{get_item, put_item, update_item, delete_item, scan_all, query_all};
+use aws_utils_dynamodb::record::{get_item, put_item, update_item, delete_item, scan_all, query_all, query};
 use aws_sdk_dynamodb::types::{AttributeValue, ReturnValue};
 use std::collections::HashMap;
 
@@ -92,7 +92,7 @@ let output = delete_item(&client, "my_table", key, None, None, None, None).await
 // Scan all items
 let items = scan_all(&client, "my_table", None, None, None, None).await?;
 
-// Query items
+// Query items (all)
 let items = query_all(
     &client,
     "my_table",
@@ -101,6 +101,21 @@ let items = query_all(
     None,
     None,
     Some(HashMap::from([(":id".to_string(), AttributeValue::S("123".to_string()))]))
+).await?;
+
+// Query items (with limit, no pagination)
+let items = query(
+    &client,
+    "my_table",
+    None,          // index_name
+    Some("id = :id"),
+    None,          // filter_expression
+    None,          // expression_attribute_names
+    Some(HashMap::from([(":id".to_string(), AttributeValue::S("123".to_string()))])),
+    None,          // consistent_read
+    None::<String>, // projection_expression
+    None::<Vec<String>>, // attributes_to_get
+    Some(10),      // limit
 ).await?;
 ```
 


### PR DESCRIPTION
## Summary

- DynamoDB の `query` 関数を追加（limit 付き単発クエリ、ページネーションなし）

## 変更点

- `record::query` 関数を新規追加
  - `query_stream` / `query_all` はページネーションで全件取得する設計
  - 新しい `query` は limit を指定して1回のAPIコールで取得（ページネーションしない）
- README, CHANGELOG, example を更新
- バージョンを 0.5.0 に更新

## 使い分け

| 関数 | 用途 |
|------|------|
| `query` | limit 付きで1回だけクエリ（ページネーションなし） |
| `query_stream` | 全件取得のストリーム（自動ページネーション） |
| `query_all` | 全件取得して Vec に収集 |